### PR TITLE
Hero: remove static blue background; only panel + water

### DIFF
--- a/src/components/SanctuaryHero.tsx
+++ b/src/components/SanctuaryHero.tsx
@@ -6,7 +6,6 @@ const VIDEO_BASE = '/videos'
 const SanctuaryHero: React.FC = () => {
   return (
     <main className="rc-hero-page">
-      <div className="rc-hero-bg" aria-hidden="true" />
       <section className="rc-hero-panel" aria-label="Recovery Compass hero">
         {/* Water video INSIDE the panel — single source of truth for branding */}
         <video className="rc-panel-video" autoPlay muted loop playsInline preload="metadata" aria-hidden="true" poster={`${VIDEO_BASE}/compass-poster-desktop.jpg`}>

--- a/src/styles/rc-hero.css
+++ b/src/styles/rc-hero.css
@@ -1,14 +1,10 @@
 /* RC hero panel styles (scoped) */
-.rc-hero-page { position: relative; min-height: 100vh; display: grid; place-items: center; overflow: hidden; background: #0b2a4a; }
+.rc-hero-page { position: relative; min-height: 100vh; display: grid; place-items: center; overflow: hidden; background: #000; }
 /* Video background (subtle water motion) */
 .rc-video-bg { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; z-index: 0; opacity: 0.6; }
-.rc-hero-bg { position: absolute; inset: 0; z-index: 1; background:
-  radial-gradient(120% 80% at 70% 30%, rgba(255,255,255,0.05), rgba(255,255,255,0) 60%),
-  linear-gradient(180deg, #1b4e8a 0%, #0b2a4a 70%);
-  pointer-events: none; }
 
 .rc-hero-panel { position: relative; z-index: 2; width: min(720px, 92vw); height: min(88vh, 760px); background: #0a0a0a; border-radius: 32px; box-shadow: 0 10px 40px rgba(0,0,0,0.35); display: grid; place-items: center; padding: 24px; overflow: hidden; }
-.rc-panel-video { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; z-index: 0; opacity: 0.85; }
+.rc-panel-video { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; z-index: 0; opacity: 1; }
  .rc-hero-panel-inner { position: relative; z-index: 1; width: 100%; height: 100%; display: grid; grid-template-rows: auto auto 1fr auto; align-items: center; justify-items: center; }
 
 /* Logo at top and larger */


### PR DESCRIPTION
- Remove static blue background layer (.rc-hero-bg) and set page backdrop to #000
- Keep only two layers: panel (CTA) + water video (inside panel)
- Set video opacity: 1 for full vibrancy

## Summary by Sourcery

Simplify the hero component by removing the static background and enhancing the water video's visual impact

Enhancements:
- Remove static blue background layer and its JSX element, setting the page backdrop to black
- Consolidate hero layers by retaining only the panel and water video and increase panel video opacity to full vibrancy