### PR TITLE
Hero: enforce black backdrop (cache-bust)

### DIFF
--- a/src/styles/rc-hero.css
+++ b/src/styles/rc-hero.css
@@ -1,5 +1,6 @@
-/* RC hero panel styles (scoped) */
-.rc-hero-page { position: relative; min-height: 100vh; display: grid; place-items: center; overflow: hidden; background: #000; }
+/* RC hero panel styles (scoped)
+   cache-buster: v2025-08-29b */
+.rc-hero-page { position: relative; min-height: 100vh; display: grid; place-items: center; overflow: hidden; background: #000 !important; }
 /* Video background (subtle water motion) */
 .rc-video-bg { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; z-index: 0; opacity: 0.6; }
 


### PR DESCRIPTION
Add !important to rc-hero-page background and cache-buster comment to ensure CloudFront picks up new CSS and removes residual static blue.

## Summary by Sourcery

Bug Fixes:
- Enforce black background on .rc-hero-page using !important and add a cache-buster comment to force CloudFront to serve updated CSS