### PR TITLE
chore(ops): add SSH guardrails docs and verifier

### DIFF
--- a/GUARDRAILS.yaml
+++ b/GUARDRAILS.yaml
@@ -1,0 +1,13 @@
+ssh:
+  github_identity_file: ~/.ssh/my_new_ed25519
+  fingerprint_sha256: "2TB7n4C+bOneTr5SXXLPzZxeivUujr9VzyVkYZZ8EO0"
+  use_keychain: true
+  add_keys_to_agent: true
+  identities_only: true
+  discovery:
+    config_command: "ssh -G github.com"
+    verify_command: "ssh-add -l -E sha256"
+    load_command: "ssh-add --apple-use-keychain ~/.ssh/my_new_ed25519"
+policy:
+  never_prompt_for_passphrase: true
+  never_echo_secrets: true

--- a/OPS_PROFILE.md
+++ b/OPS_PROFILE.md
@@ -1,0 +1,22 @@
+# OPS_PROFILE
+
+## SSH
+
+- Primary GitHub SSH identity: `~/.ssh/my_new_ed25519`
+- Fingerprint (SHA256): `2TB7n4C+bOneTr5SXXLPzZxeivUujr9VzyVkYZZ8EO0`
+- Policy:
+  - Use Keychain and agent: `UseKeychain yes`, `AddKeysToAgent yes`
+  - Force intended identity for GitHub: `IdentitiesOnly yes`
+  - Never prompt for passphrase interactively; load from Keychain
+  - Never echo secrets
+
+### Discovery and verification
+- Discover effective SSH settings for GitHub:
+  - `ssh -G github.com` (look for `identityfile ~/.ssh/my_new_ed25519` and `identitiesonly yes`)
+- Verify key is loaded in the agent:
+  - `ssh-add -l -E sha256` (should include the fingerprint above)
+- Load the key from Keychain if the agent is empty:
+  - `ssh-add --apple-use-keychain ~/.ssh/my_new_ed25519`
+
+### Expected test
+- `ssh -T git@github.com` → `Hi <USERNAME>! You've successfully authenticated, but GitHub does not provide shell access.`

--- a/scripts/verify-guardrails.sh
+++ b/scripts/verify-guardrails.sh
@@ -33,5 +33,49 @@ else
   echo "OK: No GitHub Actions workflows directory detected."
 fi
 
+echo ""
+echo "== SSH guardrails verification =="
+SSH_BIN="/usr/bin/ssh"
+SSH_ADD_BIN="/usr/bin/ssh-add"
+FINGERPRINT="SHA256:2TB7n4C+bOneTr5SXXLPzZxeivUujr9VzyVkYZZ8EO0"
+IDENTITY_FILE="$HOME/.ssh/my_new_ed25519"
+
+# Check effective ssh config for GitHub
+if ! $SSH_BIN -G github.com | grep -qiE '^user git$'; then
+  echo "FAIL: ssh -G github.com does not return 'user git'"
+  exit 1
+fi
+if ! $SSH_BIN -G github.com | grep -qiE '^identitiesonly yes$'; then
+  echo "FAIL: ssh -G github.com missing 'identitiesonly yes'"
+  exit 1
+fi
+IDENT_FROM_CFG="$($SSH_BIN -G github.com | awk '/^identityfile /{print $2; exit}')"
+if [ "$IDENT_FROM_CFG" != "$IDENTITY_FILE" ]; then
+  echo "WARN: identityfile is '$IDENT_FROM_CFG' (expected '$IDENTITY_FILE')"
+fi
+
+# Ensure correct key is present in the agent
+if ! $SSH_ADD_BIN -l -E sha256 >/dev/null 2>&1; then
+  echo "INFO: Agent is empty; loading key from Keychain..."
+  $SSH_ADD_BIN --apple-use-keychain "$IDENTITY_FILE" >/dev/null 2>&1 || true
+fi
+if ! $SSH_ADD_BIN -l -E sha256 | grep -q "$FINGERPRINT"; then
+  echo "INFO: Key not present; attempting to load from Keychain..."
+  $SSH_ADD_BIN --apple-use-keychain "$IDENTITY_FILE" >/dev/null 2>&1 || true
+fi
+if $SSH_ADD_BIN -l -E sha256 | grep -q "$FINGERPRINT"; then
+  echo "OK: SSH key fingerprint present in agent."
+else
+  echo "FAIL: SSH key fingerprint not present in agent."
+  exit 1
+fi
+
+# Probe GitHub authentication (non-interactive banner check)
+if $SSH_BIN -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+  echo "OK: GitHub SSH authentication works."
+else
+  echo "WARN: Could not confirm GitHub auth. Ensure the public key for $IDENTITY_FILE is added to GitHub."
+fi
+
 echo "== Guardrails check complete =="
 exit 0


### PR DESCRIPTION
This PR adds durable SSH guardrails so assistants never prompt for passphrases and can auto-detect the correct identity.\n\nChanges:\n- Add OPS_PROFILE.md documenting the primary GitHub SSH identity (~/.ssh/my_new_ed25519), the fingerprint (SHA256:2TB7n4C+bOneTr5SXXLPzZxeivUujr9VzyVkYZZ8EO0), and policy (UseKeychain, AddKeysToAgent, IdentitiesOnly, never prompt)\n- Add GUARDRAILS.yaml with machine-readable SSH policy and discovery/verify/load commands\n- Extend scripts/verify-guardrails.sh to verify ssh -G config, ensure key fingerprint in agent, auto-load from Keychain when needed, and probe GitHub auth\n\nRationale:\n- Provide a single source of truth for tools and AIs to discover SSH settings\n- Enforce "never prompt for passphrase" with macOS Keychain\n- Keep everything on-demand (no daemons/cron) per guardrails